### PR TITLE
auto-select region if it it's the only option

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -187,6 +187,12 @@ function populateDropdown(dd, nameProp, subDivProp, ddData) {
       opt.subdivisionData = ddData[i][subDivProp];
 
       dd.add(opt);
+
+      if (ddData.length === 1) {
+        opt.selected = true;
+        if (dd.nextDropdown) handleDropDownSelection({ target: dd });
+        if (dd === disDD) loadDistrictData();
+      }
     }
   }
 }


### PR DESCRIPTION
When a user selects a region (let's say the union Barabagi in Barisal/Barguna/Amtali) that has only one subregion (here, the mouza Barabagi), this PR will select the single subregion automatically (and recursively).

- [ ] When we have a synthetic upa/uni/mouza in Dhaka/Dhaka, test that this selects all the three levels and that it then works